### PR TITLE
Agregar el comando 'populateAlbumsForArtist'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,30 +12,32 @@
 - Para correr el linter: `npm run lint`
 
 ## Comandos (UNQfy)
-| Command               | Arguments                                                               |
-| ----------------------|:-----------------------------------------------------------------------:|
-| addArtist             | name (String), country (String)                                         |
-| removeArtist          | name (String)                                                           |
-| addAlbum              | name (String), artist (String), year (Number)                           |
-| removeAlbum           | artistName (String), albumName (String)                                 |
-| addTrack              | title (String), album (String), duration (Number), genres (List String) |
-| removeTrack           | albumName (String), trackTitle (String)                                 |
-| createPlaylist        | name (String), genres (List String), maxDuration (Number)               |
-| removePlaylist        | name (String)                                                           |
-| searchByName          | name (String)                                                           |
-| tracksByArtist        | artistName (String)                                                     |
-| tracksByGenres        | genres (List String)                                                    |
-| albumsByArtist        | artistName (String)                                                     |
-| albumTracks           | albumName (String)                                                      |
-| allArtists            |                                                                         |
-| allAlbums             |                                                                         |
-| allTracks             |                                                                         |
-| allPlaylists          |                                                                         |
-| addUser               | name (String)                                                           |
-| userListenTo          | userName (String), trackTitle (String)                                  |
-| tracksUserListenedTo  | userName (String)                                                       |
-| timesUserListenedTo   | userName (String), trackTitle (String)                                  |
-| createThisIsList      | artistName (String)                                                     |
+| Command                 | Arguments                                                               |
+| ------------------------|:-----------------------------------------------------------------------:|
+| addArtist               | name (String), country (String)                                         |
+| removeArtist            | name (String)                                                           |
+| addAlbum                | name (String), artist (String), year (Number)                           |
+| removeAlbum             | artistName (String), albumName (String)                                 |
+| addTrack                | title (String), album (String), duration (Number), genres (List String) |
+| removeTrack             | albumName (String), trackTitle (String)                                 |
+| createPlaylist          | name (String), genres (List String), maxDuration (Number)               |
+| removePlaylist          | name (String)                                                           |
+| searchByName            | name (String)                                                           |
+| tracksByArtist          | artistName (String)                                                     |
+| tracksByGenres          | genres (List String)                                                    |
+| albumsByArtist          | artistName (String)                                                     |
+| albumTracks             | albumName (String)                                                      |
+| allArtists              |                                                                         |
+| allAlbums               |                                                                         |
+| allTracks               |                                                                         |
+| allPlaylists            |                                                                         |
+| addUser                 | name (String)                                                           |
+| userListenTo            | userName (String), trackTitle (String)                                  |
+| tracksUserListenedTo    | userName (String)                                                       |
+| timesUserListenedTo     | userName (String), trackTitle (String)                                  |
+| createThisIsList        | artistName (String)                                                     |
+| populateAlbumsForArtist | artistName (String)                                                     |
+| trackLyrics             | trackTitle (String)                                                     |
 
 ## Set de pruebas desde consola 
 ```
@@ -82,6 +84,10 @@ node main.js tracksUserListenedTo userName "User1"
 node main.js timesUserListenedTo userName "User1" trackTitle "Track1"
 
 node main.js createThisIsList artistName "Artista1"
+
+node main.js populateAlbumsForArtist artistName "Artista1"
+
+node main.js trackLyrics trackTitle "Track1"
 ```
 
 ## Script que popula y realiza operaciones varias.

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ const TRACKS_USER_LISTENED_TO = 'tracksUserListenedTo';
 const TIMES_USER_LISTENED_TO = 'timesUserListenedTo';
 const CREATE_THIS_IS_LIST = 'createThisIsList';
 const POPULATE_ALBUMS_FOR_ARTIST = 'populateAlbumsForArtist';
+const TRACK_LYRICS = 'trackLyrics';
 
 const validExecutableCommands = [
   ADD_ARTIST,
@@ -53,6 +54,7 @@ const validExecutableCommands = [
   TIMES_USER_LISTENED_TO,
   CREATE_THIS_IS_LIST,
   POPULATE_ALBUMS_FOR_ARTIST,
+  TRACK_LYRICS,
 ];
 
 const commandsArguments = {
@@ -79,6 +81,7 @@ const commandsArguments = {
   [TIMES_USER_LISTENED_TO]: ['userName', 'trackTitle'],
   [CREATE_THIS_IS_LIST]: ['artistName'],
   [POPULATE_ALBUMS_FOR_ARTIST]: ['artistName'],
+  [TRACK_LYRICS]: ['trackTitle'],
 }
 
 // Retorna una instancia de UNQfy. Si existe filename, recupera la instancia desde el archivo.
@@ -339,6 +342,13 @@ async function executeCommandWithArgs(unqfy, command, args) {
       const artistName = fieldValueFromArgs(args, 'artistName');
       await unqfy.populateAlbumsForArtist(artistName);
 
+      break;
+    }
+    case TRACK_LYRICS: {
+      const trackTitle = fieldValueFromArgs(args, 'trackTitle');
+      const trackLyrics = await unqfy.trackLyrics(trackTitle);
+
+      log(`${trackTitle}'s lyrics`, trackLyrics);
       break;
     }
   }

--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ const USER_LISTEN_TO = 'userListenTo';
 const TRACKS_USER_LISTENED_TO = 'tracksUserListenedTo';
 const TIMES_USER_LISTENED_TO = 'timesUserListenedTo';
 const CREATE_THIS_IS_LIST = 'createThisIsList';
+const POPULATE_ALBUMS_FOR_ARTIST = 'populateAlbumsForArtist';
 
 const validExecutableCommands = [
   ADD_ARTIST,
@@ -51,6 +52,7 @@ const validExecutableCommands = [
   TRACKS_USER_LISTENED_TO,
   TIMES_USER_LISTENED_TO,
   CREATE_THIS_IS_LIST,
+  POPULATE_ALBUMS_FOR_ARTIST,
 ];
 
 const commandsArguments = {
@@ -76,6 +78,7 @@ const commandsArguments = {
   [TRACKS_USER_LISTENED_TO]: ['userName'],
   [TIMES_USER_LISTENED_TO]: ['userName', 'trackTitle'],
   [CREATE_THIS_IS_LIST]: ['artistName'],
+  [POPULATE_ALBUMS_FOR_ARTIST]: ['artistName'],
 }
 
 // Retorna una instancia de UNQfy. Si existe filename, recupera la instancia desde el archivo.
@@ -163,7 +166,7 @@ function log(title, object) {
   console.log(`${title}: ${JSON.stringify(object, undefined, 2)}`);
 }
 
-function executeCommandWithArgs(unqfy, command, args) {
+async function executeCommandWithArgs(unqfy, command, args) {
   validateCommand(command);
   validateCommandArguments(command, args);
 
@@ -332,16 +335,22 @@ function executeCommandWithArgs(unqfy, command, args) {
       log(`${artistName}'s top 3 listened tracks`, mostListenedTracksFromArtist);
       break;
     }
+    case POPULATE_ALBUMS_FOR_ARTIST: {
+      const artistName = fieldValueFromArgs(args, 'artistName');
+      await unqfy.populateAlbumsForArtist(artistName);
+
+      break;
+    }
   }
 }
 
-function main() {
+async function main() {
   const command = process.argv[2];
   const args = process.argv.splice(3);
   const unqfy = getUNQfy();
 
   try{
-    executeCommandWithArgs(unqfy, command, args);
+    await executeCommandWithArgs(unqfy, command, args);
   } catch(err) {
     console.error(`Unqfy Error: ${err.message}`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -311,6 +311,15 @@
         "type-detect": "^4.0.0"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -1407,6 +1416,12 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -1514,6 +1529,35 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "nock": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.4.tgz",
+      "integrity": "sha512-alqTV8Qt7TUbc74x1pKRLSENzfjp4nywovcJgi/1aXDiUxXdt7TkruSTF5MDWPP7UoPVgea4F9ghVdmX0xxnSA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -1742,6 +1786,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
+    "chai-as-promised": "^7.1.1",
     "eslint": "^7.8.1",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.22.0",
-    "mocha": "^5.0.5"
+    "mocha": "^5.0.5",
+    "nock": "^13.0.4"
   },
   "scripts": {
     "test": "mocha",

--- a/src/MusixMatch.js
+++ b/src/MusixMatch.js
@@ -1,0 +1,63 @@
+const axios = require('axios');
+const UnqfyError = require('./UnqfyError');
+
+const baseURL = 'http://api.musixmatch.com/ws/1.1';
+const apiKey = '7072af37ec9d5e6c267d78197022972d'; // This should be in an .env file.
+
+const musixMatch = axios.create({
+  baseURL
+});
+
+// https://developer.musixmatch.com/documentation/api-reference/track-search
+const getTrackByTitle = (trackTitle) => {
+  return musixMatch.get('/track.search', {
+    params: {
+      apikey: apiKey,
+      q_track: trackTitle,
+      f_has_lyrics: true
+    }})
+    .then(({ data: { message }}) => {
+      if(message.header.status_code !== 200) {
+        throw new UnqfyError(`Couldn't fetch Track: Status ${message.header.status_code}`);
+      }
+
+      return message.body.track_list[0].track;
+    })
+    .catch((error) => {
+      // We might want to do something else here.
+      throw error;
+    });
+};
+
+// https://developer.musixmatch.com/documentation/api-reference/track-lyrics-get
+const getTrackLyricsByTrackId = (trackId) => {
+  return musixMatch.get('/track.lyrics.get', {
+    params: {
+      apikey: apiKey,
+      track_id: trackId
+    }})
+    .then(({ data: { message }}) => {
+      if(message.header.status_code !== 200) {
+        throw new UnqfyError(`Couldn't fetch Track's lyrics: Status ${message.header.status_code}`);
+      }
+
+      return message.body.lyrics.lyrics_body;
+    })
+    .catch((error) => {
+      // We might want to do something else here.
+      throw error;
+    });
+};
+
+const getTrackLyrics = async (trackTitle) => {
+  const { track_id } = await getTrackByTitle(trackTitle);
+  const trackLyrics = await getTrackLyricsByTrackId(track_id)
+
+  return trackLyrics;
+};
+
+module.exports = {
+  baseURL,
+  apiKey,
+  getTrackLyrics,
+}

--- a/src/Spotify.js
+++ b/src/Spotify.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const spotifyCreds = require('../spotifyCreds');
+const UnqfyError = require('./UnqfyError');
 
 const spotify = axios.create({
   baseURL: 'https://api.spotify.com/v1',
@@ -11,32 +12,53 @@ const spotify = axios.create({
 // https://developer.spotify.com/documentation/web-api/reference-beta/#category-search
 const getArtistByName = (artistName) => {
   return spotify.get('/search', {
-    params: {
-      type: 'artist',
+    params: { 
+      type: 'artist', 
       q: artistName
     }})
     .then((response) => {
+      // Keeping only the first match since there might be many artists with a similar name.
       return response.data.artists.items[0];
     })
     .catch((error) => {
-      console.log(error.response.data.error);
+      throw new UnqfyError(`Couldn't fetch Artist: ${error.response.data.error.message}`);
     });
 };
 
 
-https://developer.spotify.com/documentation/web-api/reference-beta/#category-albums
-const getArtistAlbums = (artistId) => {
+// https://developer.spotify.com/documentation/web-api/reference-beta/#category-albums
+const getAlbumsByArtistId = (artistId) => {
   return spotify.get(`/artists/${artistId}/albums`)
     .then((response) => {
-      return response.data;
+      const artistAlbums = response.data.items;
+
+      // Response might have albums with same names but different available markets (See docs for what this value means).
+      const uniqueArtistAlbums = artistAlbums.reduce((uniqueArtistAlbums, artistAlbum) => {
+        const uniqueArtistAlbumsNames = uniqueArtistAlbums.map(artistAlbum => artistAlbum.name);
+        const albumsAlreadyExists = uniqueArtistAlbumsNames.includes(artistAlbum.name);
+  
+        if(!albumsAlreadyExists) { uniqueArtistAlbums.push(artistAlbum); }
+  
+        return uniqueArtistAlbums;
+      }, []);
+
+      // Simplify release data by only keeping the year.
+      uniqueArtistAlbums.forEach((artistAlbum) => artistAlbum.releaseYear = artistAlbum.release_date.match(/(?<year>.*?)-/).groups.year);
+  
+      return uniqueArtistAlbums;
     })
     .catch((error) => {
-      console.log(error.response.data.error);
+      throw new UnqfyError(`Couldn't fetch Artist's albums: ${error.response.data.error.message}`);
     });
 };
 
-getArtistByName('Deadmau5').then(({ id }) => {
-  getArtistAlbums(id).then((artistAlbums) => {
-    console.log(artistAlbums.items);
-  });
-});
+const getArtistAlbums = async (artistName) => {
+  const { id } = await getArtistByName(artistName);
+  const artistAlbums = await getAlbumsByArtistId(id);
+
+  return artistAlbums;
+};
+
+module.exports = {
+  getArtistAlbums
+};

--- a/src/Spotify.js
+++ b/src/Spotify.js
@@ -1,9 +1,11 @@
 const axios = require('axios');
-const spotifyCreds = require('../spotifyCreds');
 const UnqfyError = require('./UnqfyError');
 
+const baseURL = 'https://api.spotify.com/v1';
+const spotifyCreds = require('../spotifyCreds');
+
 const spotify = axios.create({
-  baseURL: 'https://api.spotify.com/v1',
+  baseURL,
   headers: {
     Authorization: `Bearer ${spotifyCreds.access_token}`
   }
@@ -25,7 +27,6 @@ const getArtistByName = (artistName) => {
     });
 };
 
-
 // https://developer.spotify.com/documentation/web-api/reference-beta/#category-albums
 const getAlbumsByArtistId = (artistId) => {
   return spotify.get(`/artists/${artistId}/albums`)
@@ -43,8 +44,12 @@ const getAlbumsByArtistId = (artistId) => {
       }, []);
 
       // Simplify release data by only keeping the year.
-      uniqueArtistAlbums.forEach((artistAlbum) => artistAlbum.releaseYear = artistAlbum.release_date.match(/(?<year>.*?)-/).groups.year);
-  
+      uniqueArtistAlbums.forEach((artistAlbum) => {
+        const releaseYearGroup = artistAlbum.release_date.match(/(.*?)-/);
+
+        artistAlbum.releaseYear = releaseYearGroup ? releaseYearGroup[1] : artistAlbum.release_date;
+      });
+
       return uniqueArtistAlbums;
     })
     .catch((error) => {
@@ -60,5 +65,6 @@ const getArtistAlbums = async (artistName) => {
 };
 
 module.exports = {
+  baseURL,
   getArtistAlbums
 };

--- a/src/Track.js
+++ b/src/Track.js
@@ -1,13 +1,24 @@
+const MusixMatch = require('./MusixMatch');
+
 class Track {
   constructor(id, title, duration, genres){
     this.id = id;
     this.title = title;
     this.duration = duration;
     this.genres = genres;
+    this.lyrics = '';
   }
 
   belongsToGenres(genresToInclude) {
     return genresToInclude.some(genreToInclude => this.genres.includes(genreToInclude));
+  }
+
+  async getLyrics() {
+    if(!this.lyrics) {
+      this.lyrics = await MusixMatch.getTrackLyrics(this.title);
+    }   
+
+    return this.lyrics;
   }
 }  
 

--- a/src/unqfy.js
+++ b/src/unqfy.js
@@ -235,6 +235,12 @@ class UNQfy {
     artistAlbums.forEach((artistAlbum) => this.addAlbum(artist.id, { name: artistAlbum.name, year: artistAlbum.releaseYear }));
   }
 
+  async trackLyrics(trackTitle) {
+    const track = this._getTrackByTitle(trackTitle);
+
+    return await track.getLyrics();
+  }
+
   save(filename) {
     const serializedData = picklify.picklify(this);
     fs.writeFileSync(filename, JSON.stringify(serializedData, null, 2));
@@ -338,5 +344,4 @@ class UNQfy {
   }
 }
 
-// COMPLETAR POR EL ALUMNO: exportar todas las clases que necesiten ser utilizadas desde un modulo cliente
 module.exports = UNQfy;

--- a/src/unqfy.js
+++ b/src/unqfy.js
@@ -1,6 +1,6 @@
 const picklify = require('picklify'); // para cargar/guarfar unqfy
 const fs = require('fs'); // para cargar/guarfar unqfy
-const { flatMap, firstN, sortRandomly } = require('./lib');
+const { flatMap, firstN } = require('./lib');
 const UnqfyError = require('./UnqfyError');
 const Artist = require('./Artist');
 const Album = require('./Album');
@@ -8,6 +8,7 @@ const Track = require('./Track');
 const Playlist = require('./Playlist');
 const User = require('./User');
 const Reproduction = require('./Reproduction');
+const Spotify = require('./Spotify');
 
 class UNQfy {
   constructor() {
@@ -225,6 +226,13 @@ class UNQfy {
     const artistTracksSortedByTimesListened = this._artistTracksSortedByTimesListened(artist);
 
     return firstN(artistTracksSortedByTimesListened, 3);
+  }
+
+  async populateAlbumsForArtist(artistName) {
+    const artist = this.getArtistByName(artistName);
+    const artistAlbums = await Spotify.getArtistAlbums(artistName);
+
+    artistAlbums.forEach((artistAlbum) => this.addAlbum(artist.id, { name: artistAlbum.name, year: artistAlbum.releaseYear }));
   }
 
   save(filename) {

--- a/test/mocks/musixmatch.js
+++ b/test/mocks/musixmatch.js
@@ -1,0 +1,75 @@
+const nock = require('nock');
+const { baseURL, apiKey } = require('../../src/MusixMatch')
+
+const mockSuccessfulTrackSearchRequest = (trackTitle, musixMatchTrackId) => {
+  nock(baseURL)
+    .get('/track.search')
+    .query({ q_track: trackTitle, f_has_lyrics: true, apikey: apiKey })
+    .reply(200, {
+      message: {
+        header: {
+          status_code: 200
+        },
+        body: {
+          track_list: [
+            {
+              track: {
+                track_id: musixMatchTrackId
+              }
+            }
+          ]
+        }
+      }
+    });
+};          
+
+const mockUnsuccessfulTrackSearchRequest = (trackTitle, httpStatus) => {
+  nock(baseURL)
+    .get('/track.search')
+    .query({ q_track: trackTitle, f_has_lyrics: true, apikey: apiKey })
+    .reply(200, { 
+      message: {
+        header: {
+          status_code: httpStatus
+        }
+      }
+    });
+};
+
+const mockSuccessfulTrackLyricsRequest = (musixMatchTrackId, trackLyrics) => {
+  nock(baseURL)
+    .get('/track.lyrics.get')
+    .query({ track_id: musixMatchTrackId, apikey: apiKey })
+    .reply(200, { 
+      message: {
+        header: {
+          status_code: 200
+        },
+        body: {
+          lyrics: {
+            lyrics_body: trackLyrics
+          }
+        }
+      }
+    });
+};
+
+const mockUnsuccessfulTrackLyricsRequest = (musixMatchTrackId, httpStatus) => {
+  nock(baseURL)
+    .get('/track.lyrics.get')
+    .query({ track_id: musixMatchTrackId, apikey: apiKey })
+    .reply(200, { 
+      message: {
+        header: {
+          status_code: httpStatus
+        }
+      }
+    });
+};
+
+module.exports = {
+  mockSuccessfulTrackSearchRequest,
+  mockUnsuccessfulTrackSearchRequest,
+  mockSuccessfulTrackLyricsRequest,
+  mockUnsuccessfulTrackLyricsRequest
+};

--- a/test/mocks/spotify.js
+++ b/test/mocks/spotify.js
@@ -1,0 +1,50 @@
+const nock = require('nock');
+
+const mockSuccessfulArtistSearchRequest = (artistName, spotifyArtistId) => {
+  nock('https://api.spotify.com/v1')
+    .get('/search')
+    .query({ type: 'artist', q: artistName })
+    .reply(200, { 
+      artists: {
+        items: [ { id: spotifyArtistId } ]
+      }
+    });
+};          
+
+const mockUnsuccessfulArtistSearchRequest = (artistName, httpStatus, errorMessage) => {
+  nock('https://api.spotify.com/v1')
+    .get('/search')
+    .query({ type: 'artist', q: artistName })
+    .reply(httpStatus, { 
+      error: {
+        status: httpStatus,
+        message: errorMessage
+      }
+    });
+};
+
+const mockSuccessfulArtistAlbumsRequest = (spotifyArtistId, artistAlbums) => {
+  nock('https://api.spotify.com/v1')
+    .get(`/artists/${spotifyArtistId}/albums`)
+    .reply(200, { 
+        items: artistAlbums
+    });
+};
+
+const mockUnsuccessfulArtistAlbumsRequest = (spotifyArtistId, httpStatus, errorMessage) => {
+  nock('https://api.spotify.com/v1')
+    .get(`/artists/${spotifyArtistId}/albums`)
+    .reply(httpStatus, { 
+      error: {
+        status: httpStatus,
+        message: errorMessage
+      }
+    });
+};
+
+module.exports = {
+  mockSuccessfulArtistSearchRequest,
+  mockUnsuccessfulArtistSearchRequest,
+  mockSuccessfulArtistAlbumsRequest,
+  mockUnsuccessfulArtistAlbumsRequest
+};

--- a/test/mocks/spotify.js
+++ b/test/mocks/spotify.js
@@ -1,7 +1,8 @@
 const nock = require('nock');
+const { baseURL } = require('../../src/Spotify')
 
 const mockSuccessfulArtistSearchRequest = (artistName, spotifyArtistId) => {
-  nock('https://api.spotify.com/v1')
+  nock(baseURL)
     .get('/search')
     .query({ type: 'artist', q: artistName })
     .reply(200, { 
@@ -12,7 +13,7 @@ const mockSuccessfulArtistSearchRequest = (artistName, spotifyArtistId) => {
 };          
 
 const mockUnsuccessfulArtistSearchRequest = (artistName, httpStatus, errorMessage) => {
-  nock('https://api.spotify.com/v1')
+  nock(baseURL)
     .get('/search')
     .query({ type: 'artist', q: artistName })
     .reply(httpStatus, { 
@@ -24,7 +25,7 @@ const mockUnsuccessfulArtistSearchRequest = (artistName, httpStatus, errorMessag
 };
 
 const mockSuccessfulArtistAlbumsRequest = (spotifyArtistId, artistAlbums) => {
-  nock('https://api.spotify.com/v1')
+  nock(baseURL)
     .get(`/artists/${spotifyArtistId}/albums`)
     .reply(200, { 
         items: artistAlbums
@@ -32,7 +33,7 @@ const mockSuccessfulArtistAlbumsRequest = (spotifyArtistId, artistAlbums) => {
 };
 
 const mockUnsuccessfulArtistAlbumsRequest = (spotifyArtistId, httpStatus, errorMessage) => {
-  nock('https://api.spotify.com/v1')
+  nock(baseURL)
     .get(`/artists/${spotifyArtistId}/albums`)
     .reply(httpStatus, { 
       error: {


### PR DESCRIPTION
**Nota: Este PR depende de https://github.com/DavidCorrea/servicios-cloud-unqfy/pull/28**

- Se agrega el comando `populateAlbumsForArtist` el cual popula los albums para un artista determinado consultandolo contra Spotify.
- Se agrega librería para poder mockear requests y responses de Spotify para poder testear.
- Se agrega librería para poder testear de una forma mas facil las promises generadas por los requests.