### PR TITLE
Generar credenciales para Musixmatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,30 +12,32 @@
 - Para correr el linter: `npm run lint`
 
 ## Comandos (UNQfy)
-| Command               | Arguments                                                               |
-| ----------------------|:-----------------------------------------------------------------------:|
-| addArtist             | name (String), country (String)                                         |
-| removeArtist          | name (String)                                                           |
-| addAlbum              | name (String), artist (String), year (Number)                           |
-| removeAlbum           | artistName (String), albumName (String)                                 |
-| addTrack              | title (String), album (String), duration (Number), genres (List String) |
-| removeTrack           | albumName (String), trackTitle (String)                                 |
-| createPlaylist        | name (String), genres (List String), maxDuration (Number)               |
-| removePlaylist        | name (String)                                                           |
-| searchByName          | name (String)                                                           |
-| tracksByArtist        | artistName (String)                                                     |
-| tracksByGenres        | genres (List String)                                                    |
-| albumsByArtist        | artistName (String)                                                     |
-| albumTracks           | albumName (String)                                                      |
-| allArtists            |                                                                         |
-| allAlbums             |                                                                         |
-| allTracks             |                                                                         |
-| allPlaylists          |                                                                         |
-| addUser               | name (String)                                                           |
-| userListenTo          | userName (String), trackTitle (String)                                  |
-| tracksUserListenedTo  | userName (String)                                                       |
-| timesUserListenedTo   | userName (String), trackTitle (String)                                  |
-| createThisIsList      | artistName (String)                                                     |
+| Command                 | Arguments                                                               |
+| ------------------------|:-----------------------------------------------------------------------:|
+| addArtist               | name (String), country (String)                                         |
+| removeArtist            | name (String)                                                           |
+| addAlbum                | name (String), artist (String), year (Number)                           |
+| removeAlbum             | artistName (String), albumName (String)                                 |
+| addTrack                | title (String), album (String), duration (Number), genres (List String) |
+| removeTrack             | albumName (String), trackTitle (String)                                 |
+| createPlaylist          | name (String), genres (List String), maxDuration (Number)               |
+| removePlaylist          | name (String)                                                           |
+| searchByName            | name (String)                                                           |
+| tracksByArtist          | artistName (String)                                                     |
+| tracksByGenres          | genres (List String)                                                    |
+| albumsByArtist          | artistName (String)                                                     |
+| albumTracks             | albumName (String)                                                      |
+| allArtists              |                                                                         |
+| allAlbums               |                                                                         |
+| allTracks               |                                                                         |
+| allPlaylists            |                                                                         |
+| addUser                 | name (String)                                                           |
+| userListenTo            | userName (String), trackTitle (String)                                  |
+| tracksUserListenedTo    | userName (String)                                                       |
+| timesUserListenedTo     | userName (String), trackTitle (String)                                  |
+| createThisIsList        | artistName (String)                                                     |
+| populateAlbumsForArtist | artistName (String)                                                     |
+| trackLyrics             | trackTitle (String)                                                     |
 
 ## Set de pruebas desde consola 
 ```
@@ -82,6 +84,10 @@ node main.js tracksUserListenedTo userName "User1"
 node main.js timesUserListenedTo userName "User1" trackTitle "Track1"
 
 node main.js createThisIsList artistName "Artista1"
+
+node main.js populateAlbumsForArtist artistName "Artista1"
+
+node main.js trackLyrics trackTitle "Track1"
 ```
 
 ## Script que popula y realiza operaciones varias.

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ const TRACKS_USER_LISTENED_TO = 'tracksUserListenedTo';
 const TIMES_USER_LISTENED_TO = 'timesUserListenedTo';
 const CREATE_THIS_IS_LIST = 'createThisIsList';
 const POPULATE_ALBUMS_FOR_ARTIST = 'populateAlbumsForArtist';
+const TRACK_LYRICS = 'trackLyrics';
 
 const validExecutableCommands = [
   ADD_ARTIST,
@@ -53,6 +54,7 @@ const validExecutableCommands = [
   TIMES_USER_LISTENED_TO,
   CREATE_THIS_IS_LIST,
   POPULATE_ALBUMS_FOR_ARTIST,
+  TRACK_LYRICS,
 ];
 
 const commandsArguments = {
@@ -79,6 +81,7 @@ const commandsArguments = {
   [TIMES_USER_LISTENED_TO]: ['userName', 'trackTitle'],
   [CREATE_THIS_IS_LIST]: ['artistName'],
   [POPULATE_ALBUMS_FOR_ARTIST]: ['artistName'],
+  [TRACK_LYRICS]: ['trackTitle'],
 }
 
 // Retorna una instancia de UNQfy. Si existe filename, recupera la instancia desde el archivo.
@@ -339,6 +342,13 @@ async function executeCommandWithArgs(unqfy, command, args) {
       const artistName = fieldValueFromArgs(args, 'artistName');
       await unqfy.populateAlbumsForArtist(artistName);
 
+      break;
+    }
+    case TRACK_LYRICS: {
+      const trackTitle = fieldValueFromArgs(args, 'trackTitle');
+      const trackLyrics = await unqfy.trackLyrics(trackTitle);
+
+      log(`${trackTitle}'s lyrics`, trackLyrics);
       break;
     }
   }

--- a/src/MusixMatch.js
+++ b/src/MusixMatch.js
@@ -1,9 +1,11 @@
 const axios = require('axios');
 const UnqfyError = require('./UnqfyError');
+
+const baseURL = 'http://api.musixmatch.com/ws/1.1';
 const apiKey = '7072af37ec9d5e6c267d78197022972d'; // This should be in an .env file.
 
 const musixMatch = axios.create({
-  baseURL: 'http://api.musixmatch.com/ws/1.1'
+  baseURL
 });
 
 // https://developer.musixmatch.com/documentation/api-reference/track-search
@@ -55,6 +57,7 @@ const getTrackLyrics = async (trackTitle) => {
 };
 
 module.exports = {
+  baseURL,
+  apiKey,
   getTrackLyrics,
-  apiKey
 }

--- a/src/MusixMatch.js
+++ b/src/MusixMatch.js
@@ -1,0 +1,60 @@
+const axios = require('axios');
+const UnqfyError = require('./UnqfyError');
+const apiKey = '7072af37ec9d5e6c267d78197022972d'; // This should be in an .env file.
+
+const musixMatch = axios.create({
+  baseURL: 'http://api.musixmatch.com/ws/1.1'
+});
+
+// https://developer.musixmatch.com/documentation/api-reference/track-search
+const getTrackByTitle = (trackTitle) => {
+  return musixMatch.get('/track.search', {
+    params: {
+      apikey: apiKey,
+      q_track: trackTitle,
+      f_has_lyrics: true
+    }})
+    .then(({ data: { message }}) => {
+      if(message.header.status_code !== 200) {
+        throw new UnqfyError(`Couldn't fetch Track: Status ${message.header.status_code}`);
+      }
+
+      return message.body.track_list[0].track;
+    })
+    .catch((error) => {
+      // We might want to do something else here.
+      throw error;
+    });
+};
+
+// https://developer.musixmatch.com/documentation/api-reference/track-lyrics-get
+const getTrackLyricsByTrackId = (trackId) => {
+  return musixMatch.get('/track.lyrics.get', {
+    params: {
+      apikey: apiKey,
+      track_id: trackId
+    }})
+    .then(({ data: { message }}) => {
+      if(message.header.status_code !== 200) {
+        throw new UnqfyError(`Couldn't fetch Track's lyrics: Status ${message.header.status_code}`);
+      }
+
+      return message.body.lyrics.lyrics_body;
+    })
+    .catch((error) => {
+      // We might want to do something else here.
+      throw error;
+    });
+};
+
+const getTrackLyrics = async (trackTitle) => {
+  const { track_id } = await getTrackByTitle(trackTitle);
+  const trackLyrics = await getTrackLyricsByTrackId(track_id)
+
+  return trackLyrics;
+};
+
+module.exports = {
+  getTrackLyrics,
+  apiKey
+}

--- a/src/Spotify.js
+++ b/src/Spotify.js
@@ -1,9 +1,11 @@
 const axios = require('axios');
-const spotifyCreds = require('../spotifyCreds');
 const UnqfyError = require('./UnqfyError');
 
+const baseURL = 'https://api.spotify.com/v1';
+const spotifyCreds = require('../spotifyCreds');
+
 const spotify = axios.create({
-  baseURL: 'https://api.spotify.com/v1',
+  baseURL,
   headers: {
     Authorization: `Bearer ${spotifyCreds.access_token}`
   }
@@ -63,5 +65,6 @@ const getArtistAlbums = async (artistName) => {
 };
 
 module.exports = {
+  baseURL,
   getArtistAlbums
 };

--- a/src/Spotify.js
+++ b/src/Spotify.js
@@ -25,7 +25,6 @@ const getArtistByName = (artistName) => {
     });
 };
 
-
 // https://developer.spotify.com/documentation/web-api/reference-beta/#category-albums
 const getAlbumsByArtistId = (artistId) => {
   return spotify.get(`/artists/${artistId}/albums`)
@@ -43,8 +42,12 @@ const getAlbumsByArtistId = (artistId) => {
       }, []);
 
       // Simplify release data by only keeping the year.
-      uniqueArtistAlbums.forEach((artistAlbum) => artistAlbum.releaseYear = artistAlbum.release_date.match(/(?<year>.*?)-/).groups.year);
-  
+      uniqueArtistAlbums.forEach((artistAlbum) => {
+        const releaseYearGroup = artistAlbum.release_date.match(/(.*?)-/);
+
+        artistAlbum.releaseYear = releaseYearGroup ? releaseYearGroup[1] : artistAlbum.release_date;
+      });
+
       return uniqueArtistAlbums;
     })
     .catch((error) => {

--- a/src/Track.js
+++ b/src/Track.js
@@ -1,13 +1,24 @@
+const MusixMatch = require('./MusixMatch');
+
 class Track {
   constructor(id, title, duration, genres){
     this.id = id;
     this.title = title;
     this.duration = duration;
     this.genres = genres;
+    this.lyrics = '';
   }
 
   belongsToGenres(genresToInclude) {
     return genresToInclude.some(genreToInclude => this.genres.includes(genreToInclude));
+  }
+
+  async getLyrics() {
+    if(!this.lyrics) {
+      this.lyrics = await MusixMatch.getTrackLyrics(this.title);
+    }   
+
+    return this.lyrics;
   }
 }  
 

--- a/src/unqfy.js
+++ b/src/unqfy.js
@@ -235,6 +235,12 @@ class UNQfy {
     artistAlbums.forEach((artistAlbum) => this.addAlbum(artist.id, { name: artistAlbum.name, year: artistAlbum.releaseYear }));
   }
 
+  async trackLyrics(trackTitle) {
+    const track = this._getTrackByTitle(trackTitle);
+
+    return await track.getLyrics();
+  }
+
   save(filename) {
     const serializedData = picklify.picklify(this);
     fs.writeFileSync(filename, JSON.stringify(serializedData, null, 2));
@@ -338,5 +344,4 @@ class UNQfy {
   }
 }
 
-// COMPLETAR POR EL ALUMNO: exportar todas las clases que necesiten ser utilizadas desde un modulo cliente
 module.exports = UNQfy;

--- a/test/mocks/musixmatch.js
+++ b/test/mocks/musixmatch.js
@@ -1,0 +1,75 @@
+const nock = require('nock');
+const { apiKey } = require('../../src/MusixMatch')
+
+const mockSuccessfulTrackSearchRequest = (trackTitle, musixMatchTrackId) => {
+  nock('http://api.musixmatch.com/ws/1.1')
+    .get('/track.search')
+    .query({ q_track: trackTitle, f_has_lyrics: true, apikey: apiKey })
+    .reply(200, {
+      message: {
+        header: {
+          status_code: 200
+        },
+        body: {
+          track_list: [
+            {
+              track: {
+                track_id: musixMatchTrackId
+              }
+            }
+          ]
+        }
+      }
+    });
+};          
+
+const mockUnsuccessfulTrackSearchRequest = (trackTitle, httpStatus) => {
+  nock('http://api.musixmatch.com/ws/1.1')
+    .get('/track.search')
+    .query({ q_track: trackTitle, f_has_lyrics: true, apikey: apiKey })
+    .reply(200, { 
+      message: {
+        header: {
+          status_code: httpStatus
+        }
+      }
+    });
+};
+
+const mockSuccessfulTrackLyricsRequest = (musixMatchTrackId, trackLyrics) => {
+  nock('http://api.musixmatch.com/ws/1.1')
+    .get('/track.lyrics.get')
+    .query({ track_id: musixMatchTrackId, apikey: apiKey })
+    .reply(200, { 
+      message: {
+        header: {
+          status_code: 200
+        },
+        body: {
+          lyrics: {
+            lyrics_body: trackLyrics
+          }
+        }
+      }
+    });
+};
+
+const mockUnsuccessfulTrackLyricsRequest = (musixMatchTrackId, httpStatus) => {
+  nock('http://api.musixmatch.com/ws/1.1')
+    .get('/track.lyrics.get')
+    .query({ track_id: musixMatchTrackId, apikey: apiKey })
+    .reply(200, { 
+      message: {
+        header: {
+          status_code: httpStatus
+        }
+      }
+    });
+};
+
+module.exports = {
+  mockSuccessfulTrackSearchRequest,
+  mockUnsuccessfulTrackSearchRequest,
+  mockSuccessfulTrackLyricsRequest,
+  mockUnsuccessfulTrackLyricsRequest
+};

--- a/test/mocks/musixmatch.js
+++ b/test/mocks/musixmatch.js
@@ -1,8 +1,8 @@
 const nock = require('nock');
-const { apiKey } = require('../../src/MusixMatch')
+const { baseURL, apiKey } = require('../../src/MusixMatch')
 
 const mockSuccessfulTrackSearchRequest = (trackTitle, musixMatchTrackId) => {
-  nock('http://api.musixmatch.com/ws/1.1')
+  nock(baseURL)
     .get('/track.search')
     .query({ q_track: trackTitle, f_has_lyrics: true, apikey: apiKey })
     .reply(200, {
@@ -24,7 +24,7 @@ const mockSuccessfulTrackSearchRequest = (trackTitle, musixMatchTrackId) => {
 };          
 
 const mockUnsuccessfulTrackSearchRequest = (trackTitle, httpStatus) => {
-  nock('http://api.musixmatch.com/ws/1.1')
+  nock(baseURL)
     .get('/track.search')
     .query({ q_track: trackTitle, f_has_lyrics: true, apikey: apiKey })
     .reply(200, { 
@@ -37,7 +37,7 @@ const mockUnsuccessfulTrackSearchRequest = (trackTitle, httpStatus) => {
 };
 
 const mockSuccessfulTrackLyricsRequest = (musixMatchTrackId, trackLyrics) => {
-  nock('http://api.musixmatch.com/ws/1.1')
+  nock(baseURL)
     .get('/track.lyrics.get')
     .query({ track_id: musixMatchTrackId, apikey: apiKey })
     .reply(200, { 
@@ -55,7 +55,7 @@ const mockSuccessfulTrackLyricsRequest = (musixMatchTrackId, trackLyrics) => {
 };
 
 const mockUnsuccessfulTrackLyricsRequest = (musixMatchTrackId, httpStatus) => {
-  nock('http://api.musixmatch.com/ws/1.1')
+  nock(baseURL)
     .get('/track.lyrics.get')
     .query({ track_id: musixMatchTrackId, apikey: apiKey })
     .reply(200, { 

--- a/test/mocks/spotify.js
+++ b/test/mocks/spotify.js
@@ -1,7 +1,8 @@
 const nock = require('nock');
+const { baseURL } = require('../../src/Spotify')
 
 const mockSuccessfulArtistSearchRequest = (artistName, spotifyArtistId) => {
-  nock('https://api.spotify.com/v1')
+  nock(baseURL)
     .get('/search')
     .query({ type: 'artist', q: artistName })
     .reply(200, { 
@@ -12,7 +13,7 @@ const mockSuccessfulArtistSearchRequest = (artistName, spotifyArtistId) => {
 };          
 
 const mockUnsuccessfulArtistSearchRequest = (artistName, httpStatus, errorMessage) => {
-  nock('https://api.spotify.com/v1')
+  nock(baseURL)
     .get('/search')
     .query({ type: 'artist', q: artistName })
     .reply(httpStatus, { 
@@ -24,7 +25,7 @@ const mockUnsuccessfulArtistSearchRequest = (artistName, httpStatus, errorMessag
 };
 
 const mockSuccessfulArtistAlbumsRequest = (spotifyArtistId, artistAlbums) => {
-  nock('https://api.spotify.com/v1')
+  nock(baseURL)
     .get(`/artists/${spotifyArtistId}/albums`)
     .reply(200, { 
         items: artistAlbums
@@ -32,7 +33,7 @@ const mockSuccessfulArtistAlbumsRequest = (spotifyArtistId, artistAlbums) => {
 };
 
 const mockUnsuccessfulArtistAlbumsRequest = (spotifyArtistId, httpStatus, errorMessage) => {
-  nock('https://api.spotify.com/v1')
+  nock(baseURL)
     .get(`/artists/${spotifyArtistId}/albums`)
     .reply(httpStatus, { 
       error: {


### PR DESCRIPTION
**Nota: Este PR depende de https://github.com/DavidCorrea/servicios-cloud-unqfy/pull/31**

- Se agrega API token para comunicarse con MusixMatch
- Se agrega comando para obtener los lyrics de un determinado Track
- Se actualiza el README con los comandos faltantes (`populateAlbumsForArtist` y `trackLyrics`)

Si bien no era del todo necesario agregar el comando de `trackLyrics`, agregarlo fue sencillo y me servía para probar rapidamente (además de los tests).