### PR TITLE
Endpoints para usuarios

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,6 +19,8 @@ const ArtistsRoute = require('./src/api/routes/Artists');
 const AlbumsRoute = require('./src/api/routes/Albums');
 const TracksRoute = require('./src/api/routes/Tracks');
 const PlaylistsRoute = require('./src/api/routes/Playlists');
+const UsersRoute = require('./src/api/routes/Users');
+const User = require('./src/models/User');
 
 // MIDDLEWARES
 app.use(bodyParser.json()); // parse application/json
@@ -45,8 +47,11 @@ app.use("/api/artists", ArtistsRoute);
 app.use("/api/albums", AlbumsRoute);
 app.use("/api/tracks", TracksRoute);
 app.use("/api/playlists", PlaylistsRoute);
+app.use("/api/users", UsersRoute);
 
 app.use((error, req, res, next) => {
+  console.log(error.message);
+
   if(error instanceof SyntaxError) {
     res.status(400).send({ status: 400, errorCode: 'BAD_REQUEST' });
   } else if(error instanceof BadRequestError) {

--- a/src/api/routes/Users.js
+++ b/src/api/routes/Users.js
@@ -1,0 +1,81 @@
+const express = require('express');
+const router = express.Router();
+const { BadRequestError } = require('../../models/UnqfyError');
+
+const validateValueFromRequestExists = (value, field) => {
+  if (!value) {
+    throw new BadRequestError(`'${field}' must be present`);
+  }
+}
+
+router.post('/', async (req, res, next) => {
+  const unqfy = req.unqfy;
+  const { name } = req.body;
+
+  try {
+    validateValueFromRequestExists(name, 'name');
+    const createdUser = unqfy.createUser(name);
+
+    res.status(201).send(createdUser);
+  } catch(error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  const unqfy = req.unqfy;
+  const { id } = req.params;
+
+  try {
+    const user = unqfy.getUserById(Number(id));
+
+    res.status(200).send(user);
+  } catch(error) {
+    next(error);
+  }
+});
+
+router.patch('/:id', async (req, res, next) => {
+  const unqfy = req.unqfy;
+  const { id } = req.params;
+  const { name } = req.body;
+
+  try {
+    validateValueFromRequestExists(name, 'name');
+    const user = unqfy.updateUserName(Number(id), name);
+
+    res.status(200).send(user);
+  } catch(error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  const unqfy = req.unqfy;
+  const { id } = req.params;
+
+  try {
+    unqfy.removeUser(Number(id));
+
+    res.status(204).send();
+  } catch(error) {
+    next(error);
+  }
+});
+
+router.post('/:id/reproductions', async (req, res, next) => {
+  const unqfy = req.unqfy;
+  const { id } = req.params;
+  const { track } = req.body;
+
+  try {
+    validateValueFromRequestExists(track, 'track');
+    unqfy.userListenToByIds(Number(id), Number(track));
+
+    res.status(201).send();
+  } catch(error) {
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/src/models/Unqfy.js
+++ b/src/models/Unqfy.js
@@ -275,7 +275,7 @@ class UNQfy {
     const user = this._getUserByName(userName);
     const track = this._getTrackByTitle(trackTitle);
 
-    user.addReproduction(new Reproduction(this._nextId(Reproduction), track));
+    this._userListenTo(user, track);
   }
 
   tracksUserListenedTo(userName) {
@@ -307,6 +307,42 @@ class UNQfy {
     const track = this._getTrackByTitle(trackTitle);
 
     return await track.getLyrics();
+  }
+
+  getUserById(userId) {
+    const user = this.users.find((user) => user.id === userId);
+    this._validateIfExist(user, 'User');
+
+    return user;
+  }
+
+  updateUserName(userId, newName) {
+    const user = this.getUserById(userId);
+    this._validateUserNameIsAvailable(newName);
+    user.name = newName;
+
+    return user;
+  }
+
+  removeUser(userId) {
+    const userToRemove = this.getUserById(userId);
+
+    this.users = this.users.filter((user) => user !== userToRemove);
+  }
+
+  userListenToByIds(userId, trackId) {
+    const user = this.getUserById(userId);
+
+    try {
+      const track = this.getTrackById(trackId);
+      this._userListenTo(user, track);
+    } catch(error){
+      if(error instanceof ResourceNotFoundError) {
+        throw new RelatedResourceNotFoundError('Track');
+      } else {
+        throw error;
+      }
+    }
   }
 
   save(filename) {
@@ -413,6 +449,10 @@ class UNQfy {
 
   _searchInPlaylistsByName(name, playlists) {
     return playlists.filter((playlist) => playlist.name.toLowerCase().includes(name.toLowerCase()));
+  }
+
+  _userListenTo(user, track) {
+    user.addReproduction(new Reproduction(this._nextId(Reproduction), track));
   }
 }
 

--- a/test/api/UNQfy.postman_collection.json
+++ b/test/api/UNQfy.postman_collection.json
@@ -853,6 +853,378 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "add user (missing required field)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "4da858e6-dc05-4e67-8f8e-e25ab080b14d",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"add user, missing required field\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        status: 400,",
+									"        errorCode: \"BAD_REQUEST\"",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}"
+						},
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "user/9999 (doesn't exist)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "bb2a458a-f2bd-420e-9d78-ce099c124c9a",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"get inexistent user\", function () {",
+									"    pm.response.to.have.status(404);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        status: 404,",
+									"        errorCode: \"RESOURCE_NOT_FOUND\"",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/9999",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"9999"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "edit user (doesn't exist)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "568d1078-79fc-474c-b694-4d0985e19808",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"get inexistent user\", function () {",
+									"    pm.response.to.have.status(404);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        status: 404,",
+									"        errorCode: \"RESOURCE_NOT_FOUND\"",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Jonny Doe\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/9999",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"9999"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete user (doesn't exist)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "80b99ca3-0242-48eb-96c0-432c7868c1ce",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"get inexistent user\", function () {",
+									"    pm.response.to.have.status(404);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        status: 404,",
+									"        errorCode: \"RESOURCE_NOT_FOUND\"",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/9999",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"9999"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "user reproduction (missing required field)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e1cc4bb5-01ae-49a5-9bd0-2ae1fb381b69",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"add playlist with missing required field\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        status: 400,",
+									"        errorCode: \"BAD_REQUEST\"",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"content-type": true
+						}
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}"
+						},
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/{{testUserId}}/reproductions",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"{{testUserId}}",
+								"reproductions"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "user reproduction (user doesn't exist)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "7b67644e-1ab7-40e1-959d-1de49208431d",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"get inexistent user\", function () {",
+									"    pm.response.to.have.status(404);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        status: 404,",
+									"        errorCode: \"RESOURCE_NOT_FOUND\"",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"track\": 8\n}"
+						},
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/9999/reproductions",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"9999",
+								"reproductions"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "user reproduction (track doesn't exist)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "061730df-3a78-4c85-a89a-d507ff5e3cfb",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"get inexistent user\", function () {",
+									"    pm.response.to.have.status(404);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        status: 404,",
+									"        errorCode: \"RELATED_RESOURCE_NOT_FOUND\"",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"track\": 9999\n}"
+						},
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/{{testUserId}}/reproductions",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"{{testUserId}}",
+								"reproductions"
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"protocolProfileBehavior": {}
@@ -3088,6 +3460,534 @@
 								"api",
 								"playlists",
 								"{{testPlaylistId}}"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "users",
+			"item": [
+				{
+					"name": "add user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "12135eec-982d-4cc9-86cb-a58c47fae0e9",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"should add user\", function () {",
+									"    pm.response.to.have.status(201);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    var userId = jsonData.id;",
+									"",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        \"id\": userId,",
+									"        \"name\": \"John Doe\",",
+									"        \"reproductions\": []",
+									"    });",
+									"",
+									"    pm.environment.set(\"testUserId\", userId);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"John Doe\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "add user (name already taken)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d7fbcabc-ba72-43b7-8ef4-6e692840834d",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"add artist with the same name\", function () {",
+									"    pm.response.to.have.status(409);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        status: 409,",
+									"        errorCode: \"RESOURCE_ALREADY_EXISTS\"        ",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"John Doe\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "2df04889-95e3-4316-bd47-2d4a9062926a",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"should get user\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        \"id\": pm.environment.get(\"testUserId\"),",
+									"        \"name\": \"John Doe\",",
+									"        \"reproductions\": []",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/{{testUserId}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"{{testUserId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "update user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b72a9843-4b26-4937-9d5b-391d756b7962",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"should get user\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        \"id\": pm.environment.get(\"testUserId\"),",
+									"        \"name\": \"Jonny Doe\",",
+									"        \"reproductions\": []",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"Jonny Doe\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/{{testUserId}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"{{testUserId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a5544313-5428-4739-a630-3d43120e28cd",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"should get user\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        \"id\": pm.environment.get(\"testUserId\"),",
+									"        \"name\": \"Jonny Doe\",",
+									"        \"reproductions\": []",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/{{testUserId}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"{{testUserId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "add another user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "82edece1-6382-42a2-a552-7563cb62dd30",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"should add another user\", function () {",
+									"    pm.response.to.have.status(201);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    var userId = jsonData.id;",
+									"",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        \"id\": userId,",
+									"        \"name\": \"Sarah Smith\",",
+									"        \"reproductions\": []",
+									"    });",
+									"",
+									"    pm.environment.set(\"testUserId2\", userId);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Sarah Smith\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete another user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8f94e555-a5e5-48e4-9b3f-11d69ef8ec32",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"delete user\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/{{testUserId2}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"{{testUserId2}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "another user (not found)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "588a0ce3-57f4-4349-addd-bd231ce934c2",
+								"exec": [
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"should not find another user\", function () {",
+									"    pm.response.to.have.status(404);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        status: 404,",
+									"        errorCode: \"RESOURCE_NOT_FOUND\"",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/{{testUserId2}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"{{testUserId2}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "user reproduction",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "bd4a2a6d-4d85-4f4f-97f5-c1bc899d5ee3",
+								"exec": [
+									"// NOTE: This tests against the objects created by the UNQfy script.",
+									"",
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"should add user\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"track\": 8\n}"
+						},
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/{{testUserId}}/reproductions",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"{{testUserId}}",
+								"reproductions"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "1806e3dc-c9d1-4403-bad0-a13d91c1a3a1",
+								"exec": [
+									"// NOTE: This tests against the objects created by the UNQfy script.",
+									"",
+									"const chai = require('chai');",
+									"chai.config.truncateThreshold = 0;",
+									"",
+									"pm.test(\"should get updated user\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"    var jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData).to.be.deep.equal({",
+									"        \"id\": pm.environment.get(\"testUserId\"),",
+									"        \"name\": \"Jonny Doe\",",
+									"        \"reproductions\": [",
+									"            {",
+									"                \"id\": 4,",
+									"                \"track\": {",
+									"                    \"id\": 8,",
+									"                    \"title\": \"Strobe\",",
+									"                    \"duration\": 311,",
+									"                    \"genres\": [",
+									"                        \"Electronica\",",
+									"                        \"House\",",
+									"                        \"Trance\"",
+									"                    ],",
+									"                    \"lyrics\": \"\"",
+									"                },",
+									"                \"timestamp\": \"2020-11-02T06:01:39.036Z\" // Falla por el tiempo inexacto. (Capaz se podria devolver horas)",
+									"            },",
+									"        ]",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:{{port}}/api/users/{{testUserId}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"users",
+								"{{testUserId}}"
 							]
 						}
 					},

--- a/test/api/UNQfy.postman_environment.json
+++ b/test/api/UNQfy.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "d20689d1-f6ab-47b2-935b-636ba4376e30",
+	"id": "b91978d5-b49f-475e-8d65-c739a31f4f35",
 	"name": "UNQfy",
 	"values": [
 		{
@@ -41,9 +41,19 @@
 			"key": "testPlaylistFromSongId",
 			"value": "0",
 			"enabled": true
+		},
+		{
+			"key": "testUserId",
+			"value": "0",
+			"enabled": true
+		},
+		{
+			"key": "testUserId2",
+			"value": "0",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-11-01T22:36:58.272Z",
+	"_postman_exported_at": "2020-11-02T06:23:06.645Z",
 	"_postman_exported_using": "Postman/7.35.0"
 }


### PR DESCRIPTION
Se agregaron los siguientes endpoints a `/api/users`:
- `POST /`
- `GET /:id`
- `PATCH /:id`
- `DELETE /:id`
- `POST /:id/reproductions`

También se agregaron casos de tests en Postman.