### PR TITLE
Se corrige el puerto para levantar local Newsletter y invocaciones de postman para monitor

### DIFF
--- a/Monitor/test/api/Monitor.postman_collection.json
+++ b/Monitor/test/api/Monitor.postman_collection.json
@@ -1,0 +1,41 @@
+{
+	"info": {
+		"_postman_id": "a28f878f-72ee-4245-bcc7-b0ddb34e06bf",
+		"name": "Monitor",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Switch",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": ""
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "LivenessDetections",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3002/api/livenessDetections",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3002",
+					"path": [
+						"api",
+						"livenessDetections"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/Newsletter/server.js
+++ b/Newsletter/server.js
@@ -4,7 +4,7 @@ const express = require('express');
 const { ResourceNotFoundError, RelatedResourceNotFoundError, ResourceAlreadyExistsError, BadRequestError } = require('./src/models/NewsletterError');
 const app = express(); 
 const NewsletterLoader = require('./src/lib/Loader');
-const port = process.env.PORT || 3002;
+const port = process.env.PORT || 3001;
 
 // Body-parser (Para acceder al body en un POST/PUT/PATCH)
 const bodyParser = require('body-parser');


### PR DESCRIPTION
Se corrige el puerto para levantar local Newsletter en caso de no poseer .env - Se suben invocaciones de postman de ejemplo para Monitor